### PR TITLE
Resolve Rails 6.1 deprecation warning

### DIFF
--- a/lib/valid_url.rb
+++ b/lib/valid_url.rb
@@ -19,7 +19,7 @@ module ActiveModel
         end
 
         unless !invalid && valid_scheme?(uri.scheme) && valid_host?(uri.host) && valid_path?(uri.path)
-          record.errors[attribute] << (options[:message] || "is an invalid URL")
+          record.errors.add(attribute, (options[:message] || "is an invalid URL"))
         end
       end
 


### PR DESCRIPTION
Resolve Rails 6.1 deprecation warning - use errors.add instead of <<